### PR TITLE
Fix permalink's for chinese text

### DIFF
--- a/portal/portal/static/js/permalink-nav.js
+++ b/portal/portal/static/js/permalink-nav.js
@@ -18,6 +18,7 @@ var PermalinkNav = {
 
                 $(".doc-content").addClass('with-permalink-nav');
 
+                var index = 0;
                 var containerOl;
                 permalinks.each(function(index) {
                     var header = $(this);
@@ -37,11 +38,12 @@ var PermalinkNav = {
 
                     if (!headerId) {
                         // Create a permalink id on header (if header does not have an id already)
-                        headerId = ("permalink-" + headerText.replace(/\W+/g, "-")).toLowerCase();
+                        headerId = ("permalink-" + index + "-" + headerText.replace(/\W+/g, "-")).toLowerCase();
                         if (headerId > maxIdLength) {
                             headerId = headerId.substring(0, maxIdLength);
                         }
                         header.attr("id", headerId);
+                        index++;
                     }
 
                     if (header.is("h1")) {

--- a/portal/portal/static/sass/base.sass
+++ b/portal/portal/static/sass/base.sass
@@ -44,6 +44,9 @@ a
     position: relative
     overflow: hidden
 
+input:focus, select:focus, textarea:focus, button:focus
+    outline: none
+
 @media (min-width: 992px)
     .fixed-left
         position: fixed

--- a/portal/portal/static/stylesheets/base.css
+++ b/portal/portal/static/stylesheets/base.css
@@ -57,8 +57,13 @@ a:visited, a:hover {
   overflow: hidden;
 }
 
+/* line 47, ../sass/base.sass */
+input:focus, select:focus, textarea:focus, button:focus {
+  outline: none;
+}
+
 @media (min-width: 992px) {
-  /* line 48, ../sass/base.sass */
+  /* line 51, ../sass/base.sass */
   .fixed-left {
     position: fixed;
     left: 0;
@@ -66,7 +71,7 @@ a:visited, a:hover {
     overflow: auto;
   }
 
-  /* line 54, ../sass/base.sass */
+  /* line 57, ../sass/base.sass */
   .fixed-right {
     position: fixed;
     right: 0;

--- a/portal/portal/static/stylesheets/screen.css
+++ b/portal/portal/static/stylesheets/screen.css
@@ -61,8 +61,13 @@ a:visited, a:hover {
   overflow: hidden;
 }
 
+/* line 47, ../sass/base.sass */
+input:focus, select:focus, textarea:focus, button:focus {
+  outline: none;
+}
+
 @media (min-width: 992px) {
-  /* line 48, ../sass/base.sass */
+  /* line 51, ../sass/base.sass */
   .fixed-left {
     position: fixed;
     left: 0;
@@ -70,7 +75,7 @@ a:visited, a:hover {
     overflow: auto;
   }
 
-  /* line 54, ../sass/base.sass */
+  /* line 57, ../sass/base.sass */
   .fixed-right {
     position: fixed;
     right: 0;


### PR DESCRIPTION
Some headers in chinese mode only contains chinese characters, which causes it to not get a valid element id.  Update code to assign a numeric value to all permalinks