### PR TITLE
Generate models documentation

### DIFF
--- a/portal/deploy/documentation.py
+++ b/portal/deploy/documentation.py
@@ -39,7 +39,7 @@ def transform(original_documentation_dir, generated_docs_dir, version):
             output_dir_name = 'book'
 
         elif 'models' in original_documentation_dir.lower():
-            doc_generator = documentation_generator.generate_book_docs
+            doc_generator = documentation_generator.generate_models_docs
             convertor = strip.models
             sm_generator = sitemap_generator.models_sitemap
             output_dir_name = 'models'
@@ -50,14 +50,17 @@ def transform(original_documentation_dir, generated_docs_dir, version):
         if not generated_docs_dir:
             # If we have not already generated the documentation, then run the document generator
             print 'Generating documentation at %s' % original_documentation_dir
-            generated_docs_dir = doc_generator(original_documentation_dir, output_dir_name)
+            if doc_generator:
+                generated_docs_dir = doc_generator(original_documentation_dir, output_dir_name)
 
         print 'Stripping documentation at %s, version %s' % (generated_docs_dir, version)
-        convertor(generated_docs_dir, version, output_dir_name)
+        if convertor:
+            convertor(generated_docs_dir, version, output_dir_name)
 
         print 'Generating sitemap for documentation at %s, gen_docs_dir=%s,  version %s' % \
               (original_documentation_dir, generated_docs_dir, version)
-        sm_generator(original_documentation_dir, generated_docs_dir, version, output_dir_name)
+        if sm_generator:
+            sm_generator(original_documentation_dir, generated_docs_dir, version, output_dir_name)
 
     except Exception as e:
         print 'Unable to process documentation: %s' % e

--- a/portal/deploy/sitemap_generator.py
+++ b/portal/deploy/sitemap_generator.py
@@ -14,7 +14,7 @@ def book_sitemap(original_documentation_dir, generated_documentation_dir, versio
 
 
 def models_sitemap(original_documentation_dir, generated_documentation_dir, version, output_dir_name):
-    github_path = 'https://github.com/PaddlePaddle/models/tree/'
+    github_path = 'https://github.com/PaddlePaddle/models/tree/develop'
 
     # Create models sitemap template
     sections = []
@@ -40,7 +40,7 @@ def models_sitemap(original_documentation_dir, generated_documentation_dir, vers
     # TODO [Jeff Wang]: Confirm the models sitemap path is correct
     versioned_dest_dir = _get_destination_documentation_dir(version, output_dir_name)
     if not os.path.isdir(versioned_dest_dir):
-        os.mkdir(versioned_dest_dir)
+        os.makedirs(versioned_dest_dir)
     sitemap_path = os.path.join(versioned_dest_dir, 'site.json')
     # Update the models.json
     with open(sitemap_path, 'w') as outfile:

--- a/portal/deploy/strip.py
+++ b/portal/deploy/strip.py
@@ -1,5 +1,5 @@
 import os
-from shutil import copyfile, rmtree
+from shutil import copyfile, copytree, rmtree
 import codecs
 
 from bs4 import BeautifulSoup
@@ -133,45 +133,11 @@ def book(generated_documentation_dir, version, output_dir_name):
 
 
 def models(generated_documentation_dir, version, output_dir_name):
-    """
-    Strip out the static and extract the body contents, headers, and body.
-    """
-    # Traverse through all the HTML pages of the dir, and take contents in the "markdown" section
-    # and transform them using a markdown library.
     destination_documentation_dir = _get_destination_documentation_dir(version, output_dir_name)
 
-    for subdir, dirs, all_files in os.walk(generated_documentation_dir):
-        for file in all_files:
-            subpath = os.path.join(subdir, file)[len(
-                generated_documentation_dir):]
-
-            # Replace .md with .html.
-            (name, extension) = os.path.splitext(subpath)
-            if extension == '.md':
-                subpath = name + '.html'
-
-            new_path = '%s/%s' % (destination_documentation_dir, subpath)
-
-            if '.md' in file or 'images' in subpath:
-                if not os.path.exists(os.path.dirname(new_path)):
-                    os.makedirs(os.path.dirname(new_path))
-
-            if '.md' in file:
-                # Convert the contents of the MD file.
-                with open(os.path.join(subdir, file)) as original_md_file:
-                    markdown_body = original_md_file.read()
-
-                    with codecs.open(new_path, 'w', 'utf-8') as new_html_partial:
-                        # Strip out the wrapping HTML
-                        new_html_partial.write(
-                            '{% verbatim %}\n' + markdown.markdown(
-                                unicode(markdown_body, 'utf-8'),
-                                extensions=['markdown.extensions.fenced_code', 'markdown.extensions.tables']
-                            ) + '\n{% endverbatim %}'
-                        )
-
-            elif 'images' in subpath:
-                copyfile(os.path.join(subdir, file), new_path)
+    if os.path.exists(destination_documentation_dir):
+        rmtree(destination_documentation_dir)
+    copytree(generated_documentation_dir, destination_documentation_dir)
 
 
 def markdown_file(source_markdown_file, version, tmp_dir):


### PR DESCRIPTION
* Moved over code from strip.py models method to document_generator.py generate_models_docs.
* Changed strip.py models method to copy over generated model docs to the correct place.
* Fixed bug with models sitemap generator