### PR TITLE
Keep the folder structure of generated Paddle document the same as wh…

### DIFF
--- a/portal/deploy/sitemap_generator.py
+++ b/portal/deploy/sitemap_generator.py
@@ -11,8 +11,15 @@ def sphinx_sitemap(original_documentation_dir, generated_documentation_dir, vers
     versioned_dest_dir = _get_destination_documentation_dir(version, output_dir_name)
     print 'GENERATING SITEMAP FOR PADDLE'
 
-    for lang in ['en', 'zh']:
-        index_html_path = '%s/%s/index.html' % (generated_documentation_dir, lang)
+    parent_path_map = { 'en': '/en/html/',
+                        'zh': '/cn/html/' }
+
+    if version == '0.10.0' or version == '0.9.0':
+        parent_path_map = { 'en': '/doc/',
+                            'zh': '/doc_cn/'}
+
+    for lang, parent_path in parent_path_map.items():
+        index_html_path = '%s/%s/index.html' % (generated_documentation_dir, parent_path)
 
         sitemap = _create_sphinx_site_map_from_index(index_html_path, lang)
         sitemap_ouput_path = os.path.join(versioned_dest_dir, 'site.%s.json' % lang)

--- a/portal/deploy/strip.py
+++ b/portal/deploy/strip.py
@@ -30,16 +30,16 @@ def sphinx(generated_documentation_dir, version, output_dir_name):
 
     new_path_map = {
         'develop': {
-            '/en/': '/en/',
-            '/zh/': '/zh/',
+            '/en/html/': '/en/',
+            '/cn/html/': '/zh/',
         },
         '0.10.0': {
-            '/en/':    '/en/',
-            '/zh/': '/zh/',
+            '/doc/':    '/en/',
+            '/doc_cn/': '/zh/',
         },
         '0.9.0': {
-            '/en/':    '/en/',
-            '/zh/': '/zh/',
+            '/doc/':    '/en/',
+            '/doc_cn/': '/zh/',
         }
     }
 

--- a/scripts/deploy/generate_paddle_docs.sh
+++ b/scripts/deploy/generate_paddle_docs.sh
@@ -26,8 +26,6 @@ cmake "$DOCS_LOCATION" -DCMAKE_Fortran_COMPILER=gfortran -DCMAKE_BUILD_TYPE=Debu
 make -j $processors gen_proto_py
 make -j $processors paddle_docs paddle_docs_cn
 
-mkdir -p $DESTINATION_DIR/zh/
-mkdir -p $DESTINATION_DIR/en/
+mkdir -p $DESTINATION_DIR
 
-cp -r $DOCS_LOCATION/doc/cn/html/* $DESTINATION_DIR/zh/.
-cp -r $DOCS_LOCATION/doc/en/html/* $DESTINATION_DIR/en/.
+cp -R $DOCS_LOCATION/doc/ $DESTINATION_DIR/.


### PR DESCRIPTION
Keep the folder structure of generated Paddle document the same as when Paddle repo builds it.  That way we can have a consistent structure when we strip and generate sitemaps from pre-generated documentation.