### PR TITLE
* Simplified Paddle docs sitemap generator by using the ul/li hierarchy

### DIFF
--- a/portal/deploy/sitemap_generator.py
+++ b/portal/deploy/sitemap_generator.py
@@ -61,73 +61,43 @@ def _create_sphinx_site_map_from_index(index_html_path, language):
         sitemap = OrderedDict()
         sitemap['title'] = OrderedDict( { 'en': 'Documentation', 'zh': '文件'} )
         sitemap['sections'] = chapters
-        soup = BeautifulSoup(html, 'lxml')
 
-        navs = soup.findAll('nav', class_='doc-menu-vertical')
+        navs = BeautifulSoup(html, 'lxml').findAll('nav', class_='doc-menu-vertical')
 
         if len(navs) > 0:
-            toc_lis = navs[0].findAll('li', { 'class': re.compile('^toctree-.*$') })
-            _create_sphinx_site_map(chapters, 0, 1, toc_lis, language)
+            chapters_container = navs[0].find('ul', recursive=False)
+            if chapters_container:
+
+                for chapter in chapters_container.find_all('li', recursive=False):
+                    _create_sphinx_site_map(chapters, chapter, language)
         else:
             print 'Cannot generate sphinx sitemap, nav.doc-menu-vertical not found in %s' % index_html_path
 
         return sitemap
 
 
-def _create_sphinx_site_map(parent_list, iterator_idx, level, li_elements, language):
-    previous_child_node = None
+def _create_sphinx_site_map(parent_list, node, language):
+    if node:
+        node_dict = OrderedDict()
+        if parent_list != None:
+            parent_list.append(node_dict)
 
-    idx = iterator_idx
-    while idx < len(li_elements):
-        li = li_elements[idx]
-        li_level = _get_toc_level(li['class'])
+        links = node.findAll('a', recursive=False)
+        if len(links) > 0:
+            first_link = links[0]
+            link_url = '/documentation/%s/%s' % (language, first_link['href'])
+            node_dict['title'] = OrderedDict({ language: first_link.text })
+            node_dict['link'] = OrderedDict({ language: link_url})
 
-        all_anchors = li.findAll('a')
+        sections = node.findAll('ul', recursive=False)
+        for section in sections:
+            sub_sections = section.findAll('li', recursive=False)
 
-        if len(all_anchors) > 0:
-            first_anchor = all_anchors[0]
+            if len(sub_sections) > 0:
+                node_dict['sections'] = []
 
-            if li_level == -1:
-                raise Exception('Invalid TOC level for li %s' % li)
-
-            if li_level == level:
-                if '#' not in first_anchor['href']:
-                    # Do not include links that contains anchor references
-                    child_node_dict = OrderedDict()
-                    previous_child_node = child_node_dict
-                    parent_list.append(child_node_dict)
-                    link_url = '/documentation/%s/%s' % (language, first_anchor['href'])
-                    child_node_dict['title'] = OrderedDict({ language: first_anchor.text})
-                    child_node_dict['link'] = OrderedDict({ language: link_url})
-
-            elif li_level > level:
-                # This is a child level, lets recursively process it
-                if previous_child_node:
-                    sub_child_list = []
-                    previous_child_node['sections'] = sub_child_list
-                    idx = _create_sphinx_site_map(sub_child_list, idx, li_level, li_elements, language)
-                else:
-                    print 'Unhandled... li_level < level'
-
-            elif li_level < level:
-                # We went up a level, lets process this line again after we return from _create_sphinx_site_map
-                return idx-1
-
-        idx += 1
-
-    return idx
-
-def _get_toc_level(toc_classes):
-    level = -1
-    prefix = 'toctree-l'
-
-    for toc_class_name in toc_classes:
-        if toc_class_name and toc_class_name.startswith(prefix):
-            level_str = toc_class_name[len(prefix):]
-            level = int(level_str)
-            break
-
-    return level
+                for sub_section in sub_sections:
+                    _create_sphinx_site_map(node_dict['sections'], sub_section, language)
 
 
 def book_sitemap(original_documentation_dir, generated_documentation_dir, version, output_dir_name):

--- a/portal/deploy/sitemap_generator.py
+++ b/portal/deploy/sitemap_generator.py
@@ -82,9 +82,8 @@ def _create_sphinx_site_map(parent_list, node, language):
         if parent_list != None:
             parent_list.append(node_dict)
 
-        links = node.findAll('a', recursive=False)
-        if len(links) > 0:
-            first_link = links[0]
+        first_link = node.find('a')
+        if first_link:
             link_url = '/documentation/%s/%s' % (language, first_link['href'])
             node_dict['title'] = OrderedDict({ language: first_link.text })
             node_dict['link'] = OrderedDict({ language: link_url})

--- a/portal/portal/templates/_content_links.html
+++ b/portal/portal/templates/_content_links.html
@@ -32,7 +32,7 @@
 
                     {% if section_title != None and section.sections == None %}
                         {% if section_link != "" %}
-                            <a href="{{ section_link|safe }}" {% if request.path == section_link %} class="active" {% endif %}>{{ section_title }}</a>
+                            <a href="{{ section_link|safe }}">{{ section_title }}</a>
                         {% endif %}
                     {% elif section_title != None and section.sections != None %}
                     <a class="collapsed" data-toggle="collapse" href="#collapse{{ forloop.parentloop.counter }}{{ forloop.counter}}">{{ section_title }}<span class="dropdown-toggle"></span></a>

--- a/portal/portal/templates/_search_0_10_0.html
+++ b/portal/portal/templates/_search_0_10_0.html
@@ -12,12 +12,12 @@
         HAS_SOURCE:  true,
         SOURCELINK_SUFFIX: ".txt",
     };
-</script>
 
-<script type="text/javascript">
-    jQuery(function() { Search.loadIndex("searchindex.js"); });
-    jQuery('.doc-content-wrap > div[role="navigation"]').remove();
-    jQuery('.doc-content-wrap').css('padding-top', 0);
+    if (location.pathname.endsWith('/search.html')) {
+        jQuery(function() { Search.loadIndex("searchindex.js"); });
+        jQuery('.doc-content-wrap > div[role="navigation"]').remove();
+        jQuery('.doc-content-wrap').css('padding-top', 0);
+    }
 </script>
 
 <script type="text/javascript" id="searchindexloader"></script>

--- a/portal/portal/templates/_search_0_9_0.html
+++ b/portal/portal/templates/_search_0_9_0.html
@@ -14,7 +14,7 @@
     };
 
     if (location.pathname.endsWith('/search.html')) {
-        //jQuery(function() { Search.loadIndex("searchindex.js"); });
+        jQuery(function() { Search.loadIndex("searchindex.js"); });
         jQuery('.doc-content-wrap > div[role="navigation"]').remove();
         jQuery('.doc-content-wrap').css('padding-top', 0);
     }

--- a/portal/portal/templates/_search_0_9_0.html
+++ b/portal/portal/templates/_search_0_9_0.html
@@ -12,12 +12,12 @@
         HAS_SOURCE:  true,
         SOURCELINK_SUFFIX: ".txt",
     };
-</script>
 
-<script type="text/javascript">
-    jQuery(function() { Search.loadIndex("searchindex.js"); });
-    jQuery('.doc-content-wrap > div[role="navigation"]').remove();
-    jQuery('.doc-content-wrap').css('padding-top', 0);
+    if (location.pathname.endsWith('/search.html')) {
+        //jQuery(function() { Search.loadIndex("searchindex.js"); });
+        jQuery('.doc-content-wrap > div[role="navigation"]').remove();
+        jQuery('.doc-content-wrap').css('padding-top', 0);
+    }
 </script>
 
 <script type="text/javascript" id="searchindexloader"></script>

--- a/portal/portal/templates/content.html
+++ b/portal/portal/templates/content.html
@@ -45,6 +45,42 @@ MathJax.Hub.Config({
     // Highlight the code, please.
     hljs.initHighlightingOnLoad();
 </script>
+
+<script>
+    // Use javascript to highlight active links on the side navigation. Since the server does not get the "#" in the
+    // request url, we cannot process the command "if request.path == section_link" reliably.
+    function highlightSideNavActiveLink(link) {
+        var fullPathWithHash = link;
+        if (fullPathWithHash == null) {
+            fullPathWithHash = location.pathname + location.hash;
+        }
+
+        $('#sidebar-nav .chapter').each(function(index) {
+            var chapter = $(this);
+            chapter.find('.section a[href]').each(function(index) {
+                link = $(this);
+                address = link.attr('href');
+                if (address == fullPathWithHash) {
+                    link.addClass('active');
+                } else {
+                    link.removeClass('active');
+                }
+            });
+        });
+    }
+
+    (function() {
+        $('#sidebar-nav .chapter a[href]').each(function(index) {
+            var link = $(this);
+            link.click(function(){
+                //event.preventDefault();
+                highlightSideNavActiveLink(link.attr('href'));
+            });
+        });
+        highlightSideNavActiveLink();
+    })();
+</script>
+
 {% if allow_search %}
 {% include CURRENT_DOCS_VERSION|search_partial %}
 {% endif %}

--- a/portal/portal/url_helper.py
+++ b/portal/portal/url_helper.py
@@ -44,6 +44,8 @@ def append_prefix_to_path(version, path):
 
         if sub_path and url_name:
             url = reverse(url_name, args=[version, sub_path])
+            # reverse method escapes #, which breaks when we try to find it in the file system.  We unescape it here
+            url = url.replace('%23', "#")
         else:
             print 'Cannot append prefix to version %s, path %s' % (version, path)
 


### PR DESCRIPTION
* Fixed issues with "#" being escaped by django's url reverse method
* Create javascript method to highlight the active links on the side menu to fix issues with URLs that contains "#"
* Fix javascript error with search.  Should only add searchindex.js on search.html page