### PR TITLE
update generate_paddle_docs.sh

### DIFF
--- a/scripts/deploy/generate_paddle_docs.sh
+++ b/scripts/deploy/generate_paddle_docs.sh
@@ -37,8 +37,6 @@ elif [ $BUILD_TYPE = "DOC_FULL" ]; then
     make -j $processors gen_proto_py
     make -j $processors paddle_python
     make -j $processors paddle_docs paddle_docs_cn paddle_api_docs
-    make -j $processors print_operators_doc
-    paddle/pybind/print_operators_doc > doc/en/html/operators.json
 fi
 
 mkdir -p $DESTINATION_DIR

--- a/scripts/deploy/generate_paddle_docs.sh
+++ b/scripts/deploy/generate_paddle_docs.sh
@@ -28,14 +28,14 @@ fi
 # TODO[thuan]: Make document generator work with paddle fluid and paddle operators docs
 
 # Compile Documentation only.
-cmake "$DOCS_LOCATION" -DCMAKE_BUILD_TYPE=Debug -DWITH_GPU=OFF -DWITH_MKL=OFF -DWITH_DOC=ON
+cmake "$DOCS_LOCATION" -DCMAKE_BUILD_TYPE=Release -DWITH_GPU=OFF -DWITH_MKL=OFF -DWITH_DOC=ON -DWITH_STYLE_CHECK=OFF
 
 if [ $BUILD_TYPE = "DOC_LITE" ]; then
     make -j $processors gen_proto_py
     make -j $processors paddle_docs paddle_docs_cn
 elif [ $BUILD_TYPE = "DOC_FULL" ]; then
-    make -j $processors gen_proto_py
-    make -j $processors paddle_python
+    make -j $processors gen_proto_py framework_py_proto
+    make -j $processors copy_paddle_pybind
     make -j $processors paddle_docs paddle_docs_cn paddle_api_docs
 fi
 


### PR DESCRIPTION
1. As #390 delete "Operators" under API menu, we could remove print_operators_doc step in generate_paddle_docs.sh.
2. fix #409 