### PR TITLE
FIx Paddle Doc Generator

### DIFF
--- a/portal/deploy/documentation.py
+++ b/portal/deploy/documentation.py
@@ -40,7 +40,7 @@ def transform(original_documentation_dir, generated_docs_dir, version, options=N
         if content_id == Content.DOCUMENTATION:
             # Generate Paddle Documentation
             _execute(original_documentation_dir, generated_docs_dir, version, content_id,
-                     documentation_generator.generate_paddle_docs, strip.sphinx,
+                     documentation_generator.generate_paddle_docs, strip.sphinx_paddle,
                      sitemap_generator.paddle_sphinx_sitemap, None, options)
 
             # Generate Paddle API Documentation
@@ -52,7 +52,7 @@ def transform(original_documentation_dir, generated_docs_dir, version, options=N
             # TODO(thuan): Fix document generator for API documentation.  For now, we are only going to support
             #   stripping/generating sitemaps for pre generated Paddle documentation
             _execute(original_documentation_dir, generated_docs_dir, version, 'api',
-                     documentation_generator.generate_paddle_docs, strip.sphinx,
+                     documentation_generator.generate_paddle_docs, strip.sphinx_paddle_api,
                      sitemap_generator.paddle_api_sphinx_sitemap, None, options)
 
         # Or if this seems like a request to build/transform the book.

--- a/portal/deploy/sitemap_generator.py
+++ b/portal/deploy/sitemap_generator.py
@@ -14,15 +14,69 @@ class SphinxContent:
 
 
 def paddle_sphinx_sitemap(original_documentation_dir, generated_documentation_dir, version, output_dir_name):
-    _sphinx_sitemap(original_documentation_dir, generated_documentation_dir, version, output_dir_name, SphinxContent.PADDLE)
+    """
+    Generates a sitemap for all languages for the paddle documentation.
+    """
+    versioned_dest_dir = get_destination_documentation_dir(version, output_dir_name)
+    print 'Generating sitemap for Paddle'
+
+    parent_path_map = { 'en': '/v2/en/html/',
+                        'zh': '/v2/cn/html/' }
+
+    for lang, parent_path in parent_path_map.items():
+        sitemap = None
+        # Using the index.html of the generated Sphinx HTML documentation,
+        # separately for each language, generate a sitemap.
+        index_html_path = '%s/%s/index.html' % (generated_documentation_dir, parent_path)
+        sitemap = _create_paddle_sphinx_site_map_from_index(index_html_path, lang, Content.DOCUMENTATION)
+        _write_sphinx_sitemap(sitemap, versioned_dest_dir, lang)
 
 
 def paddle_api_sphinx_sitemap(original_documentation_dir, generated_documentation_dir, version, output_dir_name):
-    _sphinx_sitemap(original_documentation_dir, generated_documentation_dir, version, output_dir_name, SphinxContent.PADDLE_API)
+    """
+    Generates a sitemap for all languages for the paddle documentation.
+    """
+    versioned_dest_dir = get_destination_documentation_dir(version, output_dir_name)
+    print 'Generating sitemap for Paddle API'
+
+    parent_path_map = { 'en': '/v2/api/en/html/',
+                        'zh': '/v2/api/cn/html/' }
+
+    for lang, parent_path in parent_path_map.items():
+        sitemap = None
+        # Using the index.html of the generated Sphinx HTML documentation,
+        # separately for each language, generate a sitemap.
+        index_html_path = '%s/%s/index.html' % (generated_documentation_dir, parent_path)
+
+        if lang == 'en':
+            sitemap = _create_paddle_sphinx_site_map_from_index(index_html_path, lang, Content.API)
+            _write_sphinx_sitemap(sitemap, versioned_dest_dir, lang)
+
+            # Make a copy of EN documentation for now, since we only have API docs in english
+            # We override the link language prefix
+            # TODO(thuan): Fix this once we have chinese API documentation
+            sitemap = _create_paddle_sphinx_site_map_from_index(index_html_path, 'zh', Content.API, 'en')
+            _write_sphinx_sitemap(sitemap, versioned_dest_dir, 'zh')
 
 
 def visualdl_sphinx_sitemap(original_documentation_dir, generated_documentation_dir, version, output_dir_name):
-    _sphinx_sitemap(original_documentation_dir, generated_documentation_dir, version, output_dir_name, SphinxContent.VISUALDL)
+    """
+    Generates a sitemap for all languages for the paddle documentation.
+    """
+    versioned_dest_dir = get_destination_documentation_dir(version, output_dir_name)
+
+    print 'Generating sitemap for VisualDL'
+
+    parent_path_map = { 'en': '/en/html/',
+                        'zh': '/cn/html/' }
+
+    for lang, parent_path in parent_path_map.items():
+        sitemap = None
+        # Using the index.html of the generated Sphinx HTML documentation,
+        # separately for each language, generate a sitemap.
+        index_html_path = '%s/%s/index.html' % (generated_documentation_dir, parent_path)
+        sitemap = _create_visualdl_sphinx_site_map_from_index(index_html_path, lang)
+        _write_sphinx_sitemap(sitemap, versioned_dest_dir, lang)
 
 
 def _sphinx_sitemap(original_documentation_dir, generated_documentation_dir, version, output_dir_name, sphinx_content):

--- a/portal/deploy/strip.py
+++ b/portal/deploy/strip.py
@@ -10,7 +10,35 @@ from django.conf import settings
 from deploy.utils import MARKDOWN_EXTENSIONS
 
 
-def sphinx(original_documentation_dir, generated_documentation_dir, version, output_dir_name):
+def sphinx_paddle(original_documentation_dir, generated_documentation_dir, version, output_dir_name):
+    new_path_map = {
+        'develop': {
+            '/v2/en/html/': '/en/',
+            '/v2/cn/html/': '/zh/'
+        },
+        '0.10.0': {
+            '/en/html/': '/en/',
+            '/cn/html/': '/zh/',
+        },
+        '0.9.0': {
+            '/doc/': '/en/',
+            '/doc_cn/': '/zh/',
+        }
+    }
+    sphinx(original_documentation_dir, generated_documentation_dir, version, output_dir_name, new_path_map)
+
+
+def sphinx_paddle_api(original_documentation_dir, generated_documentation_dir, version, output_dir_name):
+    new_path_map = {
+        'develop': {
+            '/v2/api/en/html/': '/en/',
+            '/v2/api/cn/html/': '/zh/'
+        }
+    }
+    sphinx(original_documentation_dir, generated_documentation_dir, version, output_dir_name, new_path_map)
+
+
+def sphinx(original_documentation_dir, generated_documentation_dir, version, output_dir_name, new_path_map=None):
     """
     Strip out the static and extract the body contents, ignoring the TOC,
     headers, and body.
@@ -22,20 +50,21 @@ def sphinx(original_documentation_dir, generated_documentation_dir, version, out
     if generated_documentation_dir:
         generated_documentation_dir = generated_documentation_dir.rstrip('/')
 
-    new_path_map = {
-        'develop': {
-            '/en/html/': '/en/',
-            '/cn/html/': '/zh/'
-        },
-        '0.10.0': {
-            '/en/html/':    '/en/',
-            '/cn/html/': '/zh/',
-        },
-        '0.9.0': {
-            '/doc/':    '/en/',
-            '/doc_cn/': '/zh/',
+    if not new_path_map:
+        new_path_map = {
+            'develop': {
+                '/en/html/': '/en/',
+                '/cn/html/': '/zh/'
+            },
+            '0.10.0': {
+                '/en/html/':    '/en/',
+                '/cn/html/': '/zh/',
+            },
+            '0.9.0': {
+                '/doc/':    '/en/',
+                '/doc_cn/': '/zh/',
+            }
         }
-    }
 
     # if the version is not supported, fall back to 'develop'
     if version not in new_path_map:


### PR DESCRIPTION
Since Paddle docs have now all moved to /api subdirectory, we need to update PPO document generator to use the /api directory.