### PR TITLE
Update Requests version to a safer one.

### DIFF
--- a/portal/requirements.txt
+++ b/portal/requirements.txt
@@ -5,7 +5,7 @@ gevent==1.2.1
 GitPython==2.1.7
 beautifulsoup4==4.6.0
 markdown==2.6.9
-requests==2.18.4
+requests>=2.20.0
 lxml==4.1.0
 protobuf==3.4.0
 recommonmark==0.4.0


### PR DESCRIPTION
---
CVE-2018-18074 More information
moderate severity
Vulnerable versions: <= 2.19.1
Patched version: 2.20.0
The Requests package through 2.19.1 before 2018-09-14 for Python sends an HTTP Authorization header to an http URI upon receiving a same-hostname https-to-http redirect, which makes it easier for remote attackers to discover credentials by sniffing the network.